### PR TITLE
Allow eager loading associations w/ a renamed fk

### DIFF
--- a/test/cumin/test_helper.clj
+++ b/test/cumin/test_helper.clj
@@ -26,13 +26,21 @@
     [:email_id "INTEGER" "NOT NULL"]
     [:body "VARCHAR"]))
 
+(def address-ddl
+  (sql/create-table-ddl "address"
+    [:id "IDENTITY" "NOT NULL" "PRIMARY KEY"]
+    [:person_id "INTEGER" "NOT NULL"]
+    [:line_1 "VARCHAR"]))
+
 (def schema
   ["DROP TABLE IF EXISTS person;"
    "DROP TABLE IF EXISTS email;"
    "DROP TABLE IF EXISTS email_body;"
+   "DROP TABLE IF EXISTS address;"
    person-ddl
    email-ddl
-   email-body-ddl])
+   email-body-ddl
+   address-ddl])
 
 (defn create-fixtures [entity & data]
   (insert entity (values data)))


### PR DESCRIPTION
Because Korma's :transforms/:prepares features allow users to rename fields, we can't necessarily assume that the foreign key passed to the database query is the same as the one in the result set. This removes that assumption from the eager-loading (`include`) stitching, by transforming the foreign key in the same way as records are transformed.

I do realize that this test case's particular kebab/snake-case dance introduces a lot of complexity for what ends up being a pretty low benefit, but it happens, and takes some work to rip out. So as a general tool on top of Korma, which allows this kind of thing, I think it's great if Cumin can handle this use case.
