### PR TITLE
Allow pagination with a primary key besides :id

### DIFF
--- a/src/cumin/pagination.clj
+++ b/src/cumin/pagination.clj
@@ -22,13 +22,14 @@
     (dec curr-page)))
 
 (defn- select-total [query]
-  (-> query
-      (dissoc ::pagination :post-queries :limit :offset :order)
-      (assoc :fields [])
-      (aggregate (count :*) :count)
-      (select)
-      (ffirst)
-      (last)))
+  (let [pk (get-in query [:ent :pk] :*)]
+    (-> query
+        (dissoc ::pagination :post-queries :limit :offset :order)
+        (assoc :fields [])
+        (aggregate (count pk) :count)
+        (select)
+        (ffirst)
+        (last))))
 
 (defn- with-page-meta [query coll]
   (let [{:keys [page per-page]} (::pagination query)

--- a/src/cumin/pagination.clj
+++ b/src/cumin/pagination.clj
@@ -22,14 +22,13 @@
     (dec curr-page)))
 
 (defn- select-total [query]
-  (let [pk (get-in query [:ent :pk] :id)]
-    (-> query
-        (dissoc ::pagination :post-queries :limit :offset :order)
-        (assoc :fields [])
-        (aggregate (count pk) :count)
-        (select)
-        (ffirst)
-        (last))))
+  (-> query
+      (dissoc ::pagination :post-queries :limit :offset :order)
+      (assoc :fields [])
+      (aggregate (count :*) :count)
+      (select)
+      (ffirst)
+      (last)))
 
 (defn- with-page-meta [query coll]
   (let [{:keys [page per-page]} (::pagination query)

--- a/src/cumin/pagination.clj
+++ b/src/cumin/pagination.clj
@@ -22,13 +22,14 @@
     (dec curr-page)))
 
 (defn- select-total [query]
-  (-> query
-      (dissoc ::pagination :post-queries :limit :offset :order)
-      (assoc :fields [])
-      (aggregate (count :id) :count)
-      (select)
-      (ffirst)
-      (last)))
+  (let [pk (get-in query [:ent :pk] :id)]
+    (-> query
+        (dissoc ::pagination :post-queries :limit :offset :order)
+        (assoc :fields [])
+        (aggregate (count pk) :count)
+        (select)
+        (ffirst)
+        (last))))
 
 (defn- with-page-meta [query coll]
   (let [{:keys [page per-page]} (::pagination query)

--- a/test/cumin/pagination_test.clj
+++ b/test/cumin/pagination_test.clj
@@ -97,4 +97,4 @@
                               (paginate :page 1 :per-page 2))))
            (str "dry run :: SELECT `person`.`id`, `person`.`age` FROM `person` ORDER BY `person`.`id` ASC LIMIT 2 OFFSET 0 :: []\n"
                 "dry run :: SELECT `person`.* FROM `person` :: []\n"
-                "dry run :: SELECT COUNT(`person`.`id`) AS `count` FROM `person` :: []\n")))))
+                "dry run :: SELECT COUNT(`person`.*) AS `count` FROM `person` :: []\n")))))

--- a/test/cumin/pagination_test.clj
+++ b/test/cumin/pagination_test.clj
@@ -97,4 +97,4 @@
                               (paginate :page 1 :per-page 2))))
            (str "dry run :: SELECT `person`.`id`, `person`.`age` FROM `person` ORDER BY `person`.`id` ASC LIMIT 2 OFFSET 0 :: []\n"
                 "dry run :: SELECT `person`.* FROM `person` :: []\n"
-                "dry run :: SELECT COUNT(`person`.*) AS `count` FROM `person` :: []\n")))))
+                "dry run :: SELECT COUNT(`person`.`id`) AS `count` FROM `person` :: []\n")))))

--- a/test/cumin/pagination_test.clj
+++ b/test/cumin/pagination_test.clj
@@ -12,6 +12,10 @@
 (defentity person-with-per-page-default
   (per-page 100))
 
+(defentity person-comment
+  (table "person_comment")
+  (pk :key))
+
 (deftest entity-per-page
   (testing "per-page"
     (is (= 100 (:cumin.pagination/per-page person-with-per-page-default)))
@@ -77,6 +81,12 @@
                              :last 1}))
 
       (is (nil? (page-info r3)))))
+
+  (testing "does not require primary key to be named :id"
+    (is (= []
+           (-> (select* person-comment)
+               (paginate :page 3)
+               select))))
 
   (testing "metadata query removes post-queries, limit, offset, and order"
     (is (= (with-out-str

--- a/test/cumin/test_helper.clj
+++ b/test/cumin/test_helper.clj
@@ -32,15 +32,23 @@
     [:person_id "INTEGER" "NOT NULL"]
     [:line_1 "VARCHAR"]))
 
+(def person-comment-ddl
+  (sql/create-table-ddl "person_comment"
+    [:key "IDENTITY" "NOT NULL" "PRIMARY KEY"]
+    [:person_id "INTEGER" "NOT NULL"]
+    [:comment "VARCHAR" "NOT NULL"]))
+
 (def schema
   ["DROP TABLE IF EXISTS person;"
    "DROP TABLE IF EXISTS email;"
    "DROP TABLE IF EXISTS email_body;"
    "DROP TABLE IF EXISTS address;"
+   "DROP TABLE IF EXISTS person_comment;"
    person-ddl
    email-ddl
    email-body-ddl
-   address-ddl])
+   address-ddl
+   person-comment-ddl])
 
 (defn create-fixtures [entity & data]
   (insert entity (values data)))


### PR DESCRIPTION
This one is more straightforward than the last one: Korma defaults to a primary key of `:id`, but it can be set to something else. 

There was one small edge case I handled: if there is _no_ primary key, I fall back to trying a column named `:id`, just as the existing behavior would've done. I can delete that fallback behavior if you'd prefer to fail fast if there's no primary key.
