### PR TITLE
Exclude update from cumin.pagination.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cumin "0.2.2"
+(defproject cumin "0.2.3"
   :description "Cumin - some spice for your Korma SQL"
   :url "https://github.com/kgann/cumin"
   :license {:name "Eclipse Public License"

--- a/src/cumin/pagination.clj
+++ b/src/cumin/pagination.clj
@@ -1,4 +1,5 @@
 (ns cumin.pagination
+  (:refer-clojure :exclude [update])
   (:require [korma.core :refer :all]
             [robert.hooke :as hooke]))
 


### PR DESCRIPTION
Avoids WARNING: update already refers to: #'clojure.core/update in namespace: cumin.pagination, being replaced by: #'korma.core/update
