### PR TITLE
Uses explicit refer vector

### DIFF
--- a/src/cumin/core.clj
+++ b/src/cumin/core.clj
@@ -1,5 +1,5 @@
 (ns cumin.core
-  (:require [korma.core :refer :all]
+  (:require [korma.core :refer [order post-query select select* where]]
             [robert.hooke :as hooke]))
 
 (defn- stitch [c1 c2 k [pk fk]]

--- a/src/cumin/core.clj
+++ b/src/cumin/core.clj
@@ -1,5 +1,5 @@
 (ns cumin.core
-  (:require [korma.core :refer [order post-query select select* where]]
+  (:require [korma.core :refer [order post-query select select* where defentity]]
             [robert.hooke :as hooke]))
 
 (defn- stitch [c1 c2 k [pk fk]]


### PR DESCRIPTION
Silences clojure 1.7 warnings about `clojure.core/update` function.